### PR TITLE
Readme: Fix crates.io graph blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Very basic scripts for drawing a graph of the crates.io
-packages. [Blog post](http://huonw.github.io/blog/2015/01/crates.io-dep-graph/).
+packages. [Blog post](http://huonw.github.io/blog/2015/01/crates.io-crate-graph/).
 
 `make` should create something semisensible, code may have to be
 edited (the `MAX_REV_DEP_COUNT` field at the top of `src/main.rs`) to


### PR DESCRIPTION
The link was broken (presumably after a file rename); this PR fixes it.
